### PR TITLE
feat: common gRPC client traits and mock

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -22,3 +22,7 @@ subsec
 prost
 logtest
 trybuild
+codegen
+oneshot
+rgba
+Struct

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/lib-common?sort=semver&color=green)
 ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/lib-common?include_prereleases)
+[![Coverage Status](https://coveralls.io/repos/github/Arrow-air/lib-common/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/lib-common)
 ![Sanity Checks](https://github.com/arrow-air/lib-common/actions/workflows/sanity_checks.yml/badge.svg?branch=main)
 ![Rust Checks](https://github.com/arrow-air/lib-common/actions/workflows/rust_ci.yml/badge.svg?branch=main)
 ![Python PEP8](https://github.com/arrow-air/lib-common/actions/workflows/python_ci.yml/badge.svg?branch=main)
-![Arrow DAO
-Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
+![Arrow DAO Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
 
 ## :telescope: Overview
 

--- a/arrow-macros/core/src/lib.rs
+++ b/arrow-macros/core/src/lib.rs
@@ -43,7 +43,7 @@ pub fn log_macros_core(input: TokenStream) -> TokenStream {
         );
 
         quote! {
-            #[doc = concat!("Writes a ", stringify!(#level), "! message to the ", #log_prefix, "::", #log_type, "logger")]
+            #[doc = concat!("Writes a ", stringify!(#level), "! message to the `", #log_prefix, "::", #log_type, "` logger")]
             #[macro_export]
             macro_rules! #macro_name {
                 ($($arg:tt)+) => {

--- a/arrow-macros/core/src/tests.rs
+++ b/arrow-macros/core/src/tests.rs
@@ -29,28 +29,28 @@ fn test_log_macro_default_prefix() {
     let input = quote!("example");
 
     let expected_output = quote!(
-        #[doc = concat!("Writes a ", stringify!(debug), "! message to the ", "app", "::", "example", "logger")]
+        #[doc = concat!("Writes a ", stringify!(debug), "! message to the `", "app", "::", "example", "` logger")]
         #[macro_export]
         macro_rules! example_debug {
             ($($arg:tt)+) => {
                 log::debug!(target: concat!("app", "::", "example"), $($arg)+)
             };
         }
-        #[doc = concat!("Writes a ", stringify!(info), "! message to the ", "app", "::", "example", "logger")]
+        #[doc = concat!("Writes a ", stringify!(info), "! message to the `", "app", "::", "example", "` logger")]
         #[macro_export]
         macro_rules! example_info {
             ($($arg:tt)+) => {
                 log::info!(target: concat!("app", "::", "example"), $($arg)+)
             };
         }
-        #[doc = concat!("Writes a ", stringify!(warn), "! message to the ", "app", "::", "example", "logger")]
+        #[doc = concat!("Writes a ", stringify!(warn), "! message to the `", "app", "::", "example", "` logger")]
         #[macro_export]
         macro_rules! example_warn {
             ($($arg:tt)+) => {
                 log::warn!(target: concat!("app", "::", "example"), $($arg)+)
             };
         }
-        #[doc = concat!("Writes a ", stringify!(error), "! message to the ", "app", "::", "example", "logger")]
+        #[doc = concat!("Writes a ", stringify!(error), "! message to the `", "app", "::", "example", "` logger")]
         #[macro_export]
         macro_rules! example_error {
             ($($arg:tt)+) => {

--- a/arrow-macros/derive/src/lib.rs
+++ b/arrow-macros/derive/src/lib.rs
@@ -4,8 +4,9 @@ use arrow_macros_core::log_macros_core;
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 
-/// Generate log macros for debug, info, warn and error functions
-/// Example:
+/// Generate log macros for debug, info, warn and error functions.
+///
+/// # Example:
 /// ```
 /// pub mod grpc {
 ///     //! Common Functions and Types Library for Arrow Services

--- a/docs/conops.md
+++ b/docs/conops.md
@@ -1,9 +1,7 @@
 # Concept of Operations - `lib-FIXME`
 
 <center>
-
-<img src="https://github.com/Arrow-air/tf-github/raw/main/src/templates/doc-banner-services.png" style="height:250px" />
-
+<img src="https://github.com/Arrow-air/tf-github/raw/main/src/templates/doc-banner-services.png"/>
 </center>
 
 Attribute | Description

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,12 +14,26 @@ repository.workspace   = true
 arrow-macros-derive = { path = "../arrow-macros/derive" }
 cargo-husky         = "1"
 chrono              = { version = "0.4", features = ["serde"] }
+futures             = { version = "0.3", optional = true }
+http                = { version = "0.2", optional = true }
+hyper               = { version = "0.14", optional = true }
+log                 = { version = "0.4", optional = true }
+prost               = { version = "0.11", optional = true }
 prost-types         = "0.11"
+tonic               = { version = "0.8", optional = true, features = ["gzip"] }
+tower               = { version = "0.4", optional = true }
 trybuild            = "1.0"
 
+[dependencies.tokio]
+features = ["macros", "rt-multi-thread", "sync", "fs", "signal", "full"]
+optional = true
+version  = "1.28"
+
 [dev-dependencies]
-log     = "0.4"
-logtest = "2.0"
+lib-common = { path = ".", features = ["grpc", "grpc_mock"] }
+log        = "0.4"
+logtest    = "2.0"
+spectral   = "0.6"
 
 [dev-dependencies.cargo-husky]
 default-features = false          # Disable features which are enabled by default
@@ -28,3 +42,7 @@ version          = "1"
 
 [lib]
 name = "lib_common"
+
+[features]
+grpc      = ["tonic", "futures", "log", "prost"]
+grpc_mock = ["grpc", "tokio", "tower", "http", "hyper"]

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,50 @@
+![Arrow Banner](https://github.com/Arrow-air/.github/raw/main/profile/assets/arrow_v2_twitter-banner_neu.png)
+
+# `lib-common` Library
+
+![GitHub stable release (latest by date)](https://img.shields.io/github/v/release/Arrow-air/lib-common?sort=semver&color=green)
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Arrow-air/lib-common?include_prereleases)
+[![Coverage Status](https://coveralls.io/repos/github/Arrow-air/lib-common/badge.svg?branch=develop)](https://coveralls.io/github/Arrow-air/lib-common)
+![Sanity Checks](https://github.com/arrow-air/lib-common/actions/workflows/sanity_checks.yml/badge.svg?branch=main)
+![Rust Checks](https://github.com/arrow-air/lib-common/actions/workflows/rust_ci.yml/badge.svg?branch=main)
+![Python PEP8](https://github.com/arrow-air/lib-common/actions/workflows/python_ci.yml/badge.svg?branch=main)
+![Arrow DAO
+Discord](https://img.shields.io/discord/853833144037277726?style=plastic)
+
+## Overview
+
+Common functions and data types across the Arrow microservices.
+
+### Feature flags
+
+#### grpc
+<p style="background:rgba(255,181,77,0.16);padding:0.75em;">
+The <code style="background:rgba(41,24,0,0.1);">grpc</code> module is always enabled for Rust tests.
+</p>
+
+Enabling the `grpc` feature will add the following dependencies:
+- `tonic`
+- `futures`
+- `log`
+- `prost`
+
+Enabling the `grpc` module gives access to the [`Client`](grpc::Client) and
+[`ClientConnect`](grpc::ClientConnect) Traits, in addition to the [`GrpcClient`](grpc::GrpcClient) Struct.
+
+
+#### grpc_mock
+<p style="background:rgba(255,181,77,0.16);padding:0.75em;">
+The <code style="background:rgba(41,24,0,0.1);">grpc_mock</code> module is always enabled for Rust tests.
+</p>
+
+Enabling the `grpc_mock` feature will add the following dependencies:
+- `grpc`
+- `tokio`
+- `tower`
+- `http`
+- `hyper`
+
+Enabling the `grpc_mock` module gives access to a
+[`start_server`](grpc::mock::start_server) function which provides a wrapper to
+start any gRPC server implementation in a non-blocking thread. This can be used
+when running unit tests.

--- a/lib/src/grpc/README.md
+++ b/lib/src/grpc/README.md
@@ -1,0 +1,43 @@
+# gRPC Client helper `Traits` and `Macros`
+
+<p style="background:rgba(255,181,77,0.16);padding:0.75em;">
+Only available with <code style="background:rgba(41,24,0,0.1);">grpc</code> feature enabled
+</p>
+
+Example usage:
+```rust
+use lib_common::grpc::*;
+use lib_common::grpc_client;
+use tonic::{transport::Channel, Request};
+use tonic::async_trait;
+
+pub mod grpc_client {
+    #![allow(unused_qualifications)]
+    include!("mock/grpc_client.rs");
+}
+use grpc_client::{client::MockClient, ReadyRequest};
+
+// Call gRPC client macro provided by lib_common::grpc.
+// This will implement the [`ClientConnect`] trait for the [`GrpcClient<MockClient<Channel>>`] object.
+grpc_client!(MockClient);
+
+#[tokio::main]
+async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    let (host, port) = get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+
+    // Initialize a new GrpcClient providing the connection host and port and a name to identify the client
+    let grpc_client = GrpcClient::<MockClient<Channel>>::new_client(
+        &host,
+        port,
+        "my_client",
+    );
+
+    // Get a client connection
+    let mut connection = grpc_client.get_client().await?;
+
+    // Call the gRPC functions
+    let result = connection.is_ready(Request::new(ReadyRequest {})).await?;
+
+    Ok(())
+}
+```

--- a/lib/src/grpc/mock/README.md
+++ b/lib/src/grpc/mock/README.md
@@ -1,0 +1,8 @@
+# gRPC Client and Server mock helpers
+
+<p style="background:rgba(255,181,77,0.16);padding:0.75em;">
+Only available with <code style="background:rgba(41,24,0,0.1);">grpc_mock</code> feature enabled
+</p>
+
+Provides access to a mock Server and Client which are mainly used for unit testing the `grpc` module itself.
+The [`start_server`] function can be useful for external modules as well.

--- a/lib/src/grpc/mock/grpc_client.rs
+++ b/lib/src/grpc/mock/grpc_client.rs
@@ -1,0 +1,70 @@
+/// Ready Request object
+///
+/// No arguments
+#[derive(Eq, Copy)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadyRequest {}
+/// Ready Response object
+#[derive(Eq, Copy)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadyResponse {
+    /// True if ready
+    #[prost(bool, tag = "1")]
+    pub ready: bool,
+}
+/// Generated client implementations.
+pub mod client {
+    #![allow(missing_docs)]
+    use std::convert::TryInto;
+    use tonic::body::BoxBody;
+    use tonic::client::{Grpc, GrpcService};
+    use tonic::codegen::*;
+    use tonic::transport::{Endpoint, Error};
+
+    /// Heartbeat
+    #[derive(Debug, Clone)]
+    pub struct MockClient<T> {
+        inner: Grpc<T>,
+    }
+    impl MockClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, Error>
+        where
+            D: TryInto<Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> MockClient<T>
+    where
+        T: GrpcService<BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        /// Common Interfaces
+        pub async fn is_ready(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReadyRequest>,
+        ) -> Result<tonic::Response<super::ReadyResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path =
+                http::uri::PathAndQuery::from_static("/grpc.ready.service.RpcService/isReady");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}

--- a/lib/src/grpc/mock/grpc_server.rs
+++ b/lib/src/grpc/mock/grpc_server.rs
@@ -1,0 +1,132 @@
+/// Ready Request object
+///
+/// No arguments
+#[derive(Eq, Copy)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadyRequest {}
+/// Ready Response object
+#[derive(Eq, Copy)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadyResponse {
+    /// True if ready
+    #[prost(bool, tag = "1")]
+    pub ready: bool,
+}
+/// Generated server implementations.
+pub mod server {
+    #![allow(missing_docs)]
+    use ::http::Request;
+    use tonic::codegen::{Service, *};
+
+    /// Generated trait containing gRPC methods that should be implemented for use with RpcServiceServer.
+    #[async_trait]
+    pub trait MockService: Send + Sync + 'static {
+        /// Simple call to check if the server is ready to accept connections
+        async fn is_ready(
+            &self,
+            request: tonic::Request<super::ReadyRequest>,
+        ) -> Result<tonic::Response<super::ReadyResponse>, tonic::Status>;
+    }
+    /// Storage service
+    #[derive(Debug)]
+    pub struct MockServer<T: MockService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: MockService> MockServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+    }
+    impl<T, B> Service<Request<B>> for MockServer<T>
+    where
+        T: MockService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/grpc.ready.service.RpcService/isReady" => {
+                    #[allow(non_camel_case_types)]
+                    struct isReadySvc<T: MockService>(pub Arc<T>);
+                    impl<T: MockService> tonic::server::UnaryService<super::ReadyRequest> for isReadySvc<T> {
+                        type Response = super::ReadyResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ReadyRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).is_ready(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = isReadySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: MockService> Clone for MockServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: MockService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: MockService> tonic::server::NamedService for MockServer<T> {
+        const NAME: &'static str = "grpc.ready.service.RpcService";
+    }
+}

--- a/lib/src/grpc/mock/mod.rs
+++ b/lib/src/grpc/mock/mod.rs
@@ -1,0 +1,201 @@
+#![doc = include_str!("README.md")]
+
+use std::convert::Infallible;
+use tokio::sync::oneshot::{self, Sender};
+use tonic::body::BoxBody;
+use tonic::transport::{NamedService, Server};
+use tower::Service;
+
+/// Starts a [`tokio`] server listening on 50051 for our `MockService`
+/// # Example
+/// ```
+/// use lib_common::grpc::mock::start_server;
+///
+/// pub mod mock_server {
+///     #![allow(unused_qualifications)]
+///     include!("grpc_server.rs");
+/// }
+/// use mock_server::server::{MockService, MockServer};
+/// use mock_server::*;
+///
+/// async fn start_mock_server() {
+///     let service = GrpcMockSuccess::default();
+///     let shutdown_tx = start_server("0.0.0.0:50051", MockServer::new(service)).await.expect("Could not start server.");
+///     // send server shutdown signal
+///     shutdown_tx.send(()).expect("Unable to shutdown server");
+/// }
+///
+/// #[derive(Default, Debug, Clone, Copy)]
+/// pub struct GrpcMockSuccess {}
+///
+/// #[tonic::async_trait]
+/// impl MockService for GrpcMockSuccess {
+///     async fn is_ready(
+///         &self,
+///         request: tonic::Request<ReadyRequest>,
+///     ) -> Result<tonic::Response<ReadyResponse>, tonic::Status> {
+///         println!("Got a request: {:?}", request);
+///         let reply = ReadyResponse { ready: true };
+///         Ok(tonic::Response::new(reply))
+///     }
+/// }
+/// ```
+pub async fn start_server<S>(
+    addr: &str,
+    service: S,
+) -> Result<Sender<()>, Box<dyn std::error::Error>>
+where
+    S: Service<http::Request<hyper::Body>, Response = http::Response<BoxBody>, Error = Infallible>
+        + NamedService
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    println!("Starting server on {}", addr);
+
+    // Create channels to send shutdown event
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let addr = match addr.parse() {
+        Ok(addr) => Ok(addr),
+        Err(e) => {
+            println!("Parse error: {e}");
+            Err(e)
+        }
+    }?;
+
+    let result = tokio::spawn(async move {
+        let server = Server::builder()
+            .add_service(service)
+            .serve_with_shutdown(addr, async {
+                shutdown_rx.await.ok();
+            });
+
+        if let Err(err) = server.await {
+            eprintln!("server error: {:?}", err);
+            panic!("error");
+        }
+    });
+
+    // Server takes some time to start, so wait a bit for that
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+    // Check if the server is still running
+    if result.is_finished() {
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Server stopped!?!?",
+        )));
+    }
+
+    Ok(shutdown_tx)
+}
+
+#[macro_export]
+/// Implements [`ClientConnect`](super::ClientConnect) trait for provided gRPC Client
+/// Starts a mock server and creates a connection using a duplex channel
+macro_rules! grpc_mock_client {
+    ($rpc_service_client: ident) => {
+        #[tonic::async_trait]
+        impl $crate::grpc::ClientConnect<$rpc_service_client<Channel>>
+            for $crate::grpc::GrpcClient<$rpc_service_client<Channel>>
+        {
+            /// Get a connected client object
+            async fn connect(
+                &self,
+            ) -> Result<$rpc_service_client<Channel>, tonic::transport::Error> {
+                pub mod grpc_server {
+                    #![allow(unused_qualifications)]
+                    include!("grpc_server.rs");
+                }
+                use grpc_server::server::{MockServer, MockService};
+                /// Mock struct to implement our MockService for success tests
+                #[derive(Default, Debug, Clone, Copy)]
+                pub struct GrpcMockSuccess {}
+                #[tonic::async_trait]
+                impl MockService for GrpcMockSuccess {
+                    async fn is_ready(
+                        &self,
+                        request: tonic::Request<grpc_server::ReadyRequest>,
+                    ) -> Result<tonic::Response<grpc_server::ReadyResponse>, tonic::Status>
+                    {
+                        println!("Got a request: {:?}", request);
+                        let reply = grpc_server::ReadyResponse { ready: true };
+                        Ok(tonic::Response::new(reply))
+                    }
+                }
+                let (client, server) = tokio::io::duplex(1024);
+
+                let grpc_service = GrpcMockSuccess::default();
+
+                tokio::spawn(async move {
+                    tonic::transport::Server::builder()
+                        .add_service(MockServer::new(grpc_service))
+                        .serve_with_incoming(futures::stream::iter(vec![Ok::<_, std::io::Error>(
+                            server,
+                        )]))
+                        .await
+                });
+
+                // Move client to an option so we can _move_ the inner value
+                // on the first attempt to connect. All other attempts will fail.
+                let mut client = Some(client);
+                let channel = tonic::transport::Endpoint::try_from("http://[::]:50051")?
+                    .connect_with_connector(tower::service_fn(move |_: tonic::transport::Uri| {
+                        let client = client.take();
+
+                        async move {
+                            if let Some(client) = client {
+                                Ok(client)
+                            } else {
+                                Err(std::io::Error::new(
+                                    std::io::ErrorKind::Other,
+                                    "Client already taken",
+                                ))
+                            }
+                        }
+                    }))
+                    .await?;
+
+                Ok($rpc_service_client::new(channel))
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::grpc::{Client, ClientConnect, GrpcClient};
+    use tonic::transport::Channel;
+
+    pub mod grpc_client {
+        #![allow(unused_qualifications)]
+        include!("grpc_client.rs");
+    }
+    use grpc_client::client::MockClient;
+    use grpc_client::ReadyRequest;
+    grpc_mock_client!(MockClient);
+
+    #[tokio::test]
+    async fn test_mock_client_connect() {
+        let name = "mock_client";
+        let server_host = "localhost";
+        let server_port = 50050;
+
+        let client: GrpcClient<MockClient<Channel>> =
+            GrpcClient::new_client(server_host, server_port, name);
+
+        let connection = client.get_client().await;
+        println!("{:?}", connection);
+        assert!(connection.is_ok());
+
+        // See if we can send a request
+        let result = connection
+            .unwrap()
+            .is_ready(tonic::Request::new(ReadyRequest {}))
+            .await;
+        println!("{:?}", result);
+        assert!(result.is_ok());
+    }
+}

--- a/lib/src/grpc/mod.rs
+++ b/lib/src/grpc/mod.rs
@@ -1,0 +1,477 @@
+#![doc = include_str!("README.md")]
+
+use futures::lock::Mutex;
+use std::sync::Arc;
+use tonic::{async_trait, Status};
+
+#[cfg(any(feature = "grpc_mock", test))]
+pub mod mock;
+
+#[cfg(not(test))]
+use arrow_macros_derive::log_macros;
+#[cfg(not(test))]
+use log;
+#[cfg(not(test))]
+log_macros!("grpc", "app::grpc::clients");
+
+#[cfg(test)]
+use log::{debug as grpc_debug, error as grpc_error, info as grpc_info, warn as grpc_warn};
+
+/// Generic gRPC Client trait to let the [`Client<T>`] trait know that `T` has a `connect` function
+#[async_trait]
+pub trait ClientConnect<T>
+where
+    Self: Sized + Client<T>,
+    T: Send + Clone,
+{
+    /// wrapper for gRPC client connect function
+    async fn connect(&self) -> Result<T, tonic::transport::Error>;
+
+    /// Get a copy of the connected client
+    async fn get_client(&self) -> Result<T, Status> {
+        grpc_info!("(get_client) {} entry.", self.get_name());
+
+        let arc = Arc::clone(self.get_inner());
+        let mut client_option = arc.lock().await;
+
+        // if already connected, return the client, else, try connect
+        match &mut *client_option {
+            Some(client) => {
+                grpc_debug!(
+                    "(get_client) already connected to {} server at {}. Returning cloned client.",
+                    self.get_name(),
+                    self.get_address()
+                );
+                Ok(client.clone())
+            }
+            None => {
+                grpc_warn!("(get_client) client not connected yet.");
+                grpc_info!(
+                    "(get_client) connecting to {} server at {}.",
+                    self.get_name(),
+                    self.get_address()
+                );
+
+                match self.connect().await {
+                    Ok(client) => {
+                        grpc_info!(
+                            "(get_client) success: connected to {} server at {}.",
+                            self.get_name(),
+                            self.get_address()
+                        );
+                        *client_option = Some(client.clone());
+                        Ok(client)
+                    }
+                    Err(e) => {
+                        let error = format!(
+                            "(get_client) couldn't connect to {} server at {}; {}.",
+                            self.get_name(),
+                            self.get_address(),
+                            e
+                        );
+                        grpc_error!("{}", error);
+                        Err(Status::internal(error))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Generic gRPC Client trait to provide wrapper for [`GrpcClient`] struct creation
+#[async_trait]
+pub trait Client<T>
+where
+    T: Send + Clone,
+{
+    /// Invalidates the client if set
+    async fn invalidate(&mut self);
+
+    /// Create new [`GrpcClient`]
+    fn new_client(server_host: &str, server_port: u16, name: &str) -> GrpcClient<T> {
+        let opt: Option<T> = None;
+        GrpcClient {
+            inner: Arc::new(Mutex::new(opt)),
+            address: format!("http://{server_host}:{server_port}"),
+            name: name.to_string(),
+        }
+    }
+
+    /// Get name string for client
+    fn get_name(&self) -> String;
+
+    /// Get connection string for client
+    fn get_address(&self) -> String;
+
+    /// Get GrpcClient inner value
+    fn get_inner(&self) -> &Arc<Mutex<Option<T>>>;
+}
+
+/// Wrapper struct for our gRPC clients
+#[derive(Debug, Clone)]
+pub struct GrpcClient<T> {
+    inner: Arc<Mutex<Option<T>>>,
+    address: String,
+    name: String,
+}
+
+#[async_trait]
+impl<T> Client<T> for GrpcClient<T>
+where
+    T: Send + Clone,
+{
+    async fn invalidate(&mut self) {
+        let arc = Arc::clone(&self.inner);
+        let mut client = arc.lock().await;
+        *client = None;
+    }
+
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+    fn get_address(&self) -> String {
+        self.address.clone()
+    }
+    fn get_inner(&self) -> &Arc<Mutex<Option<T>>> {
+        &self.inner
+    }
+}
+
+/// Returns a ([String], [i32]) host, port from provided environment variables.
+/// Returns default values (localhost, 50051) if environment variable is not found.
+pub fn get_endpoint_from_env(env_host: &str, env_port: &str) -> (String, u16) {
+    grpc_debug!("(get_endpoint_from_env) entry");
+
+    let host = match std::env::var(env_host) {
+        Ok(val) => val,
+        Err(_) => {
+            grpc_error!(
+                "(get_endpoint_from_env) {} undefined, using default [localhost].",
+                env_host
+            );
+            "localhost".to_string()
+        }
+    };
+    let port: u16 = match std::env::var(env_port) {
+        Ok(val) => match val.parse::<u16>() {
+            Ok(val) => val,
+            Err(_) => {
+                grpc_error!(
+                    "(get_endpoint_from_env) {} is not a valid u16 type, using default [50051].",
+                    env_port
+                );
+                50051
+            }
+        },
+        Err(_) => {
+            grpc_error!(
+                "(get_endpoint_from_env) {} undefined, using default [50051].",
+                env_port
+            );
+            50051
+        }
+    };
+
+    grpc_info!("(get_endpoint_from_env) host [{}], port [{}].", host, port);
+    (host, port)
+}
+
+#[macro_export]
+/// Implements [`ClientConnect`] trait for provided gRPC Client
+macro_rules! grpc_client {
+    ($rpc_service_client: ident) => {
+        #[async_trait]
+        impl $crate::grpc::ClientConnect<$rpc_service_client<Channel>>
+            for $crate::grpc::GrpcClient<$rpc_service_client<Channel>>
+        {
+            /// Get a connected client object
+            async fn connect(
+                &self,
+            ) -> Result<$rpc_service_client<Channel>, tonic::transport::Error> {
+                $rpc_service_client::connect(self.get_address()).await
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mock::*;
+    use super::*;
+    use tonic::{transport::Channel, Request, Response};
+
+    pub mod grpc_client {
+        #![allow(unused_qualifications)]
+        include!("mock/grpc_client.rs");
+    }
+    use grpc_client::{client::MockClient, ReadyRequest};
+    pub mod grpc_server {
+        #![allow(unused_qualifications)]
+        include!("mock/grpc_server.rs");
+    }
+    use grpc_server::server::{MockServer, MockService};
+    grpc_client!(MockClient);
+
+    /// Mock struct to implement our MockService for success tests
+    #[derive(Default, Debug, Clone, Copy)]
+    pub struct GrpcMockSuccess {}
+
+    #[tonic::async_trait]
+    impl MockService for GrpcMockSuccess {
+        async fn is_ready(
+            &self,
+            request: Request<grpc_server::ReadyRequest>,
+        ) -> Result<Response<grpc_server::ReadyResponse>, Status> {
+            println!("Got a request: {:?}", request);
+            let reply = grpc_server::ReadyResponse { ready: true };
+            Ok(Response::new(reply))
+        }
+    }
+
+    /// Mock struct to implement our MockService for fail tests
+    #[derive(Default, Debug, Clone, Copy)]
+    pub struct GrpcMockFail {}
+
+    #[tonic::async_trait]
+    impl MockService for GrpcMockFail {
+        async fn is_ready(
+            &self,
+            request: Request<grpc_server::ReadyRequest>,
+        ) -> Result<Response<grpc_server::ReadyResponse>, Status> {
+            println!("Got a request: {:?}", request);
+            Err(Status::internal("Mock not ready."))
+        }
+    }
+
+    impl PartialEq for MockClient<Channel> {
+        fn eq(&self, other: &Self) -> bool {
+            self == other
+        }
+    }
+
+    #[test]
+    fn test_get_endpoint_from_env() {
+        // test_get_endpoint_from_env_with_defaults
+        std::env::remove_var("GRPC_PORT");
+        std::env::remove_var("GRPC_HOST");
+        let (server_host, server_port) = get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+        assert_eq!(server_host, "localhost");
+        assert_eq!(server_port, 50051);
+
+        // test_get_endpoint_from_env_with_valid_env_vars
+        std::env::set_var("GRPC_PORT", "50055");
+        std::env::set_var("GRPC_HOST", "custom_host");
+        let (server_host, server_port) = get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+        assert_eq!(server_host, "custom_host");
+        assert_eq!(server_port, 50055);
+
+        // test_get_endpoint_from_env_with_invalid_port
+        std::env::set_var("GRPC_PORT", "invalid");
+        let (server_host, server_port) = get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
+        assert_eq!(server_host, "custom_host");
+        assert_eq!(server_port, 50051);
+    }
+
+    #[tokio::test]
+    async fn test_mock_client_new_client() {
+        let name = "mock_client";
+        let server_host = "localhost";
+        let server_port = 50050;
+
+        let client: GrpcClient<MockClient<Channel>> =
+            GrpcClient::new_client(server_host, server_port, name);
+
+        assert_eq!(client.name, name);
+        assert_eq!(
+            client.address,
+            format!("http://{}:{}", server_host, server_port)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grpc_client_server_not_ready() {
+        let name = "test_client";
+        let server_host = "localhost";
+        let server_port = 50051;
+
+        grpc_info!("ensure_server_running");
+
+        let service = GrpcMockFail::default();
+        let server_started = start_server(
+            &format!("0.0.0.0:{}", server_port),
+            MockServer::new(service),
+        )
+        .await;
+        assert!(server_started.is_ok());
+        grpc_info!("Server started");
+        let shutdown_tx = server_started.unwrap();
+
+        let mock_client: GrpcClient<MockClient<Channel>> =
+            GrpcClient::new_client(server_host, server_port, name);
+
+        // First time get_client, should create a new connection
+        // See if we can send a request
+        let result = mock_client.get_client().await;
+        assert!(result.is_ok());
+
+        // See if we can send a request
+        let result = result
+            .unwrap()
+            .is_ready(Request::new(ReadyRequest {}))
+            .await;
+        grpc_debug!("{:?}", result);
+        assert!(result.is_err());
+        if let Err(result) = result {
+            grpc_debug!("{}", result.message());
+            assert_eq!(result.message(), "Mock not ready.");
+        }
+        // Send server the shutdown request
+        shutdown_tx.send(()).expect("Could not stop server.");
+    }
+
+    // Running all tests that require a running server at once.
+    // We need a known Channel for the ClientConnect implementation.
+    #[tokio::test]
+    async fn test_grpc_client_connected() {
+        let name = "test_client";
+        let server_host = "localhost";
+        let server_port = 50052;
+
+        grpc_info!("ensure_server_running");
+
+        let service = GrpcMockSuccess::default();
+        let server_started = start_server(
+            &format!("0.0.0.0:{}", server_port),
+            MockServer::new(service),
+        )
+        .await;
+        assert!(server_started.is_ok());
+        grpc_info!("Server started");
+        let shutdown_tx = server_started.unwrap();
+
+        let mock_client: GrpcClient<MockClient<Channel>> =
+            GrpcClient::new_client(server_host, server_port, name);
+
+        // First time get_client, should create a new connection
+        // See if we can send a request
+        let result = mock_client.get_client().await;
+        assert!(result.is_ok());
+
+        // See if we can send a request
+        let result = result
+            .unwrap()
+            .is_ready(Request::new(ReadyRequest {}))
+            .await;
+        grpc_debug!("{:?}", result);
+        assert!(result.is_ok());
+
+        // Second time get_client, should already be connected
+        let client = mock_client.get_client().await;
+        assert!(client.is_ok());
+
+        // See if we can send a request
+        let result = client
+            .unwrap()
+            .is_ready(Request::new(ReadyRequest {}))
+            .await;
+        grpc_debug!("{:?}", result);
+        assert!(result.is_ok());
+
+        // Send server the shutdown request
+        shutdown_tx.send(()).expect("Could not stop server.");
+        // Give the server some time to shut down
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+        // Third time get_client, should not be connected
+        let client = mock_client.get_client().await;
+        assert!(client.is_ok());
+        // See if we get an error when server unreachable
+        let result = client
+            .unwrap()
+            .is_ready(Request::new(ReadyRequest {}))
+            .await;
+        grpc_debug!("{:?}", result);
+        assert!(result.is_err());
+
+        // See if we can recover from a server reconnect
+        grpc_info!("ensure_server_running");
+        let server_started = start_server(
+            &format!("0.0.0.0:{}", server_port),
+            MockServer::new(service),
+        )
+        .await;
+        assert!(server_started.is_ok());
+        grpc_info!("Server started");
+        let shutdown_tx = server_started.unwrap();
+
+        // Fourth time get_client, should be connected again
+        let client = mock_client.get_client().await;
+        assert!(client.is_ok());
+        // See if we get an answer from the server again
+        let result = client
+            .unwrap()
+            .is_ready(Request::new(ReadyRequest {}))
+            .await;
+        grpc_debug!("{:?}", result);
+        assert!(result.is_ok());
+
+        // Send server the shutdown request
+        shutdown_tx.send(()).expect("Could not stop server.");
+    }
+
+    #[tokio::test]
+    async fn test_grpc_client_invalidate() {
+        let name = "test_client";
+        let server_host = "localhost";
+        let server_port = 50053;
+
+        let mut mock_client: GrpcClient<MockClient<Channel>> =
+            GrpcClient::new_client(server_host, server_port, name);
+
+        mock_client.invalidate().await;
+
+        let arc = Arc::clone(&mock_client.inner);
+        let client_option = arc.lock().await;
+        assert_eq!(&*client_option, &None);
+    }
+
+    #[tokio::test]
+    async fn test_grpc_server_address_parse_error() {
+        let server_host = "invalid";
+        let server_port = 50054;
+        let service = GrpcMockSuccess::default();
+        let server_started = start_server(
+            &format!("{}:{}", server_host, server_port),
+            MockServer::new(service),
+        )
+        .await;
+        assert!(server_started.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_grpc_server_port_already_in_use() {
+        let server_host = "0.0.0.0";
+        let server_port = 50055;
+        let service = GrpcMockSuccess::default();
+
+        let server_started = start_server(
+            &format!("{}:{}", server_host, server_port),
+            MockServer::new(service),
+        )
+        .await;
+        assert!(server_started.is_ok());
+        grpc_info!("Server started");
+        let shutdown_tx = server_started.unwrap();
+
+        let result = start_server::<MockServer<GrpcMockSuccess>>(
+            &format!("{}:{}", server_host, server_port),
+            MockServer::new(service),
+        )
+        .await;
+        print!("{:?}", result);
+        assert!(result.is_err());
+
+        // Send server the shutdown request
+        shutdown_tx.send(()).expect("Could not stop server.");
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,7 @@
-//! Common Functions and Types Library for Arrow Services
+#![doc = include_str!("../README.md")]
+
+#[cfg(any(feature = "grpc", test))]
+pub mod grpc;
 pub mod time;
 
 pub use arrow_macros_derive::log_macros;


### PR DESCRIPTION
Adds mock gRPC client and server which can be used for tests.
Also adds common function to start a given gRPC server implementation in a non-blocking thread.
In addition, a GrpcClient struct has been added, with accompanying Traits, which can be used for all clients.